### PR TITLE
chore: Upgrade to Rust edition 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- upgrade to Rust edition 2024
+
 ## [1.3.5] - 2023-11-02
 
 ### Fixes

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Jujutsu subcommand for submitting pull requests for individual, a
 repository = "https://github.com/getcord/spr"
 homepage = "https://github.com/getcord/spr"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 exclude = [".github", ".gitignore"]
 
 [[bin]]

--- a/spr/src/commands/amend.rs
+++ b/spr/src/commands/amend.rs
@@ -79,9 +79,5 @@ pub async fn amend(
     }
     jj.rewrite_commit_messages(&mut pc)?;
 
-    if failure {
-        Err(Error::empty())
-    } else {
-        Ok(())
-    }
+    if failure { Err(Error::empty()) } else { Ok(()) }
 }

--- a/spr/src/commands/close.rs
+++ b/spr/src/commands/close.rs
@@ -10,7 +10,7 @@ use std::process::Stdio;
 use indoc::formatdoc;
 
 use crate::{
-    error::{add_error, Error, Result},
+    error::{Error, Result, add_error},
     github::{PullRequestState, PullRequestUpdate},
     jj::PreparedCommit,
     message::MessageSection,

--- a/spr/src/commands/format.rs
+++ b/spr/src/commands/format.rs
@@ -58,9 +58,5 @@ pub async fn format(
     }
     jj.rewrite_commit_messages(&mut pc)?;
 
-    if failure {
-        Err(Error::empty())
-    } else {
-        Ok(())
-    }
+    if failure { Err(Error::empty()) } else { Ok(()) }
 }

--- a/spr/src/commands/init.rs
+++ b/spr/src/commands/init.rs
@@ -196,7 +196,9 @@ fn validate_branch_prefix(branch_prefix: &str) -> Result<()> {
         || branch_prefix.ends_with(".lock")
         || branch_prefix.starts_with('.')
     {
-        return Err(Error::new("Branch prefix cannot have slash-separated component beginning with a dot . or ending with the sequence .lock"));
+        return Err(Error::new(
+            "Branch prefix cannot have slash-separated component beginning with a dot . or ending with the sequence .lock",
+        ));
     }
 
     if branch_prefix.contains("..") {

--- a/spr/src/config.rs
+++ b/spr/src/config.rs
@@ -66,12 +66,11 @@ impl Config {
             r#"^\s*https?://github.com/([\w\-\.]+)/([\w\-\.]+)/pull/(\d+)([/?#].*)?\s*$"#
         );
         let m = regex.captures(text);
-        if let Some(caps) = m {
-            if self.owner == caps.get(1).unwrap().as_str()
-                && self.repo == caps.get(2).unwrap().as_str()
-            {
-                return Some(caps.get(3).unwrap().as_str().parse().unwrap());
-            }
+        if let Some(caps) = m
+            && self.owner == caps.get(1).unwrap().as_str()
+            && self.repo == caps.get(2).unwrap().as_str()
+        {
+            return Some(caps.get(3).unwrap().as_str().parse().unwrap());
         }
 
         None

--- a/spr/src/git.rs
+++ b/spr/src/git.rs
@@ -16,7 +16,7 @@ use crate::{
     config::Config,
     error::{Error, Result, ResultExt},
     github::GitHubBranch,
-    message::{build_commit_message, parse_message, MessageSection, MessageSectionsMap},
+    message::{MessageSection, MessageSectionsMap, build_commit_message, parse_message},
     utils::run_command,
 };
 use debug_ignore::DebugIgnore;
@@ -165,12 +165,10 @@ impl Git {
             }
         }
 
-        if updating {
-            if let Some(oid) = parent_oid {
-                repo.find_reference("HEAD")?
-                    .resolve()?
-                    .set_target(oid, "spr updated commit messages")?;
-            }
+        if updating && let Some(oid) = parent_oid {
+            repo.find_reference("HEAD")?
+                .resolve()?
+                .set_target(oid, "spr updated commit messages")?;
         }
 
         Ok(())
@@ -1237,9 +1235,11 @@ mod tests {
                         "Should get exactly one commit for change ID"
                     );
                     // Verify the commit message was parsed correctly
-                    assert!(commits[0]
-                        .message
-                        .contains_key(&crate::message::MessageSection::Title));
+                    assert!(
+                        commits[0]
+                            .message
+                            .contains_key(&crate::message::MessageSection::Title)
+                    );
                 }
                 Err(e) => {
                     // Change ID resolution might fail if the format changed, but that's OK

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 use crate::{
     error::{Error, Result, ResultExt},
-    message::{build_github_body, parse_message, MessageSection, MessageSectionsMap},
+    message::{MessageSection, MessageSectionsMap, build_github_body, parse_message},
 };
 use std::collections::{HashMap, HashSet};
 

--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -14,7 +14,7 @@ use std::{
 use crate::{
     config::Config,
     error::{Error, Result, ResultExt},
-    message::{build_commit_message, parse_message, MessageSection, MessageSectionsMap},
+    message::{MessageSection, MessageSectionsMap, build_commit_message, parse_message},
 };
 use git2::Oid;
 

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -23,14 +23,12 @@ fn get_config_value(key: &str, git_config: &git2::Config) -> Option<String> {
     if let Ok(output) = std::process::Command::new("jj")
         .args(["config", "get", key])
         .output()
+        && output.status.success()
+        && let Ok(value) = String::from_utf8(output.stdout)
     {
-        if output.status.success() {
-            if let Ok(value) = String::from_utf8(output.stdout) {
-                let trimmed = value.trim();
-                if !trimmed.is_empty() {
-                    return Some(trimmed.to_string());
-                }
-            }
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
         }
     }
 
@@ -43,16 +41,14 @@ fn get_config_bool(key: &str, git_config: &git2::Config) -> Option<bool> {
     if let Ok(output) = std::process::Command::new("jj")
         .args(["config", "get", key])
         .output()
+        && output.status.success()
+        && let Ok(value) = String::from_utf8(output.stdout)
     {
-        if output.status.success() {
-            if let Ok(value) = String::from_utf8(output.stdout) {
-                let trimmed = value.trim().to_lowercase();
-                if trimmed == "true" {
-                    return Some(true);
-                } else if trimmed == "false" {
-                    return Some(false);
-                }
-            }
+        let trimmed = value.trim().to_lowercase();
+        if trimmed == "true" {
+            return Some(true);
+        } else if trimmed == "false" {
+            return Some(false);
         }
     }
 

--- a/spr/tests/master_base_fix_test.rs
+++ b/spr/tests/master_base_fix_test.rs
@@ -370,5 +370,7 @@ fn test_directly_based_on_master_logic_fix() {
         "New logic should correctly return false for stacked child"
     );
 
-    println!("Test passed: Fixed logic correctly identifies stacked commits as not directly based on master");
+    println!(
+        "Test passed: Fixed logic correctly identifies stacked commits as not directly based on master"
+    );
 }

--- a/spr/tests/stacked_changes_test.rs
+++ b/spr/tests/stacked_changes_test.rs
@@ -162,8 +162,7 @@ fn test_stacked_changes_parent_immutability_bug() {
     // This assertion will fail with the current buggy implementation
     // After fixing, the parent change ID should remain the same when only processing the child
     assert_eq!(
-        parent_change_id_before,
-        parent_change_id_after,
+        parent_change_id_before, parent_change_id_after,
         "Parent change ID changed when only child revision was processed - this indicates the parent became immutable"
     );
 }

--- a/spr/tests/stacked_pr_diff_test.rs
+++ b/spr/tests/stacked_pr_diff_test.rs
@@ -213,8 +213,7 @@ fn test_stacked_pr_shows_only_child_diff() {
 
     // The parent change ID should remain the same
     assert_eq!(
-        parent_change_id_before,
-        parent_change_id_after,
+        parent_change_id_before, parent_change_id_after,
         "Parent change ID changed when processing child commit - this indicates the parent became immutable"
     );
 


### PR DESCRIPTION
Upgrades Cargo.toml to Rust edition 2024.

- Formats all files using `rustfmt --edition 2024`.
- Collapses some nested `if` statements, as recommended by clippy.