### PR TITLE
Fix PR creation ordering and add :: operator support

### DIFF
--- a/spr/src/commands/amend.rs
+++ b/spr/src/commands/amend.rs
@@ -22,8 +22,8 @@ pub struct AmendOptions {
     #[clap(long)]
     base: Option<String>,
 
-    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@'
-    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'
+    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@' or 'a::c'.
+    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'.
     #[clap(short = 'r', long)]
     revision: Option<String>,
 }
@@ -35,14 +35,15 @@ pub async fn amend(
     config: &crate::config::Config,
 ) -> Result<()> {
     // Determine revision and whether to use range mode
-    let (use_range_mode, base_rev, target_rev) = crate::revision_utils::parse_revision_and_range(
-        opts.revision.as_deref(),
-        opts.all,
-        opts.base.as_deref(),
-    )?;
+    let (use_range_mode, base_rev, target_rev, is_inclusive) =
+        crate::revision_utils::parse_revision_and_range(
+            opts.revision.as_deref(),
+            opts.all,
+            opts.base.as_deref(),
+        )?;
 
     let mut pc = if use_range_mode {
-        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev)?
+        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev, is_inclusive)?
     } else {
         vec![jj.get_prepared_commit_for_revision(config, &target_rev)?]
     };

--- a/spr/src/commands/close.rs
+++ b/spr/src/commands/close.rs
@@ -27,8 +27,8 @@ pub struct CloseOptions {
     #[clap(long)]
     base: Option<String>,
 
-    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@'
-    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'
+    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@' or 'a::c'.
+    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'.
     #[clap(short = 'r', long)]
     revision: Option<String>,
 }
@@ -42,14 +42,15 @@ pub async fn close(
     let mut result = Ok(());
 
     // Determine revision and whether to use range mode
-    let (use_range_mode, base_rev, target_rev) = crate::revision_utils::parse_revision_and_range(
-        opts.revision.as_deref(),
-        opts.all,
-        opts.base.as_deref(),
-    )?;
+    let (use_range_mode, base_rev, target_rev, is_inclusive) =
+        crate::revision_utils::parse_revision_and_range(
+            opts.revision.as_deref(),
+            opts.all,
+            opts.base.as_deref(),
+        )?;
 
     let mut prepared_commits = if use_range_mode {
-        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev)?
+        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev, is_inclusive)?
     } else {
         vec![jj.get_prepared_commit_for_revision(config, &target_rev)?]
     };

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -48,8 +48,8 @@ pub struct DiffOptions {
     #[clap(long)]
     base: Option<String>,
 
-    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@'
-    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'
+    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@' or 'a::c'.
+    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'.
     #[clap(short = 'r', long)]
     revision: Option<String>,
 }
@@ -66,16 +66,17 @@ pub async fn diff(
     let mut result = Ok(());
 
     // Determine revision and whether to use range mode
-    let (use_range_mode, base_rev, target_rev) = crate::revision_utils::parse_revision_and_range(
-        opts.revision.as_deref(),
-        opts.all,
-        opts.base.as_deref(),
-    )?;
+    let (use_range_mode, base_rev, target_rev, is_inclusive) =
+        crate::revision_utils::parse_revision_and_range(
+            opts.revision.as_deref(),
+            opts.all,
+            opts.base.as_deref(),
+        )?;
 
     // Get commits to process
     let mut prepared_commits = if use_range_mode {
         // Get range of commits from base to target
-        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev)?
+        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev, is_inclusive)?
     } else {
         // Just get the single specified revision
         vec![jj.get_prepared_commit_for_revision(config, &target_rev)?]

--- a/spr/src/commands/format.rs
+++ b/spr/src/commands/format.rs
@@ -21,8 +21,8 @@ pub struct FormatOptions {
     #[clap(long)]
     base: Option<String>,
 
-    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@'
-    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'
+    /// Jujutsu revision(s) to operate on. Can be a single revision like '@' or a range like 'main..@' or 'a::c'.
+    /// If a range is provided, behaves like --all mode. If not specified, uses '@-'.
     #[clap(short = 'r', long)]
     revision: Option<String>,
 }
@@ -33,14 +33,15 @@ pub async fn format(
     config: &crate::config::Config,
 ) -> Result<()> {
     // Determine revision and whether to use range mode
-    let (use_range_mode, base_rev, target_rev) = crate::revision_utils::parse_revision_and_range(
-        opts.revision.as_deref(),
-        opts.all,
-        opts.base.as_deref(),
-    )?;
+    let (use_range_mode, base_rev, target_rev, is_inclusive) =
+        crate::revision_utils::parse_revision_and_range(
+            opts.revision.as_deref(),
+            opts.all,
+            opts.base.as_deref(),
+        )?;
 
     let mut pc = if use_range_mode {
-        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev)?
+        jj.get_prepared_commits_from_to(config, &base_rev, &target_rev, is_inclusive)?
     } else {
         vec![jj.get_prepared_commit_for_revision(config, &target_rev)?]
     };

--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -80,13 +80,15 @@ impl Jujutsu {
         config: &Config,
         from_revision: &str,
         to_revision: &str,
+        is_inclusive: bool,
     ) -> Result<Vec<PreparedCommit>> {
         // Get commit range using jj
+        let operator = if is_inclusive { "::" } else { ".." };
         let output = self.run_captured_with_args([
             "log",
             "--no-graph",
             "-r",
-            &format!("{}..{}", from_revision, to_revision),
+            &format!("{}{}{}", from_revision, operator, to_revision),
             "--template",
             "commit_id ++ \"\\n\"",
         ])?;
@@ -471,7 +473,7 @@ mod tests {
         let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
 
         // Test getting commit range
-        let result = jj.get_prepared_commits_from_to(&config, "@----", "@-");
+        let result = jj.get_prepared_commits_from_to(&config, "@----", "@-", false);
         assert!(
             result.is_ok(),
             "Failed to get commit range: {:?}",

--- a/spr/src/revision_utils.rs
+++ b/spr/src/revision_utils.rs
@@ -5,32 +5,46 @@
 use crate::error::{Error, Result};
 
 /// Parse revision parameter and determine if it should be treated as a range
-/// Returns (use_range_mode, base_rev, target_rev)
+/// Returns (use_range_mode, base_rev, target_rev, is_inclusive)
+/// where is_inclusive indicates whether :: (inclusive) or .. (exclusive) operator was used
 pub fn parse_revision_and_range(
     revision_opt: Option<&str>,
     all_mode: bool,
     base_opt: Option<&str>,
-) -> Result<(bool, String, String)> {
+) -> Result<(bool, String, String, bool)> {
     let revision = revision_opt.unwrap_or("@-");
 
     if revision.contains("..") {
-        // Range specified in revision (e.g., "main..@") - this overrides --all mode
+        // Range specified in revision with .. operator (e.g., "main..@") will exclude base. This
+        // overrides --all mode.
         let parts: Vec<&str> = revision.split("..").collect();
         if parts.len() == 2 {
-            Ok((true, parts[0].to_string(), parts[1].to_string()))
+            Ok((true, parts[0].to_string(), parts[1].to_string(), false))
         } else {
             Err(Error::new(format!(
                 "Invalid revision range format: {}. Use 'base..target' format",
                 revision
             )))
         }
+    } else if revision.contains("::") {
+        // Range specified in revision with :: operator (e.g., "A::B") will be inclusive on both
+        // ends. This overrides --all mode.
+        let parts: Vec<&str> = revision.split("::").collect();
+        if parts.len() == 2 {
+            Ok((true, parts[0].to_string(), parts[1].to_string(), true))
+        } else {
+            Err(Error::new(format!(
+                "Invalid revision range format: {}. Use 'base::target' format",
+                revision
+            )))
+        }
     } else if all_mode {
         // Explicit --all mode
         let base = base_opt.unwrap_or("trunk()");
-        Ok((true, base.to_string(), revision.to_string()))
+        Ok((true, base.to_string(), revision.to_string(), false))
     } else {
         // Single revision
-        Ok((false, String::new(), revision.to_string()))
+        Ok((false, String::new(), revision.to_string(), false))
     }
 }
 
@@ -41,56 +55,72 @@ mod tests {
     #[test]
     fn test_default_revision_is_at_minus() {
         // Test that when no revision is specified, it defaults to "@-"
-        let (use_range_mode, base_rev, target_rev) =
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(None, false, None).unwrap();
 
         assert!(!use_range_mode);
         assert_eq!(base_rev, "");
         assert_eq!(target_rev, "@-");
+        assert!(!is_inclusive);
     }
 
     #[test]
     fn test_explicit_revision_overrides_default() {
         // Test that when a revision is explicitly specified, it overrides the default
-        let (use_range_mode, base_rev, target_rev) =
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(Some("@"), false, None).unwrap();
 
         assert!(!use_range_mode);
         assert_eq!(base_rev, "");
         assert_eq!(target_rev, "@");
+        assert!(!is_inclusive);
     }
 
     #[test]
     fn test_range_revision_detection() {
         // Test that range revision syntax is correctly detected
-        let (use_range_mode, base_rev, target_rev) =
+
+        // Test exclusive range (..) operator
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(Some("main..@"), false, None).unwrap();
 
         assert!(use_range_mode);
         assert_eq!(base_rev, "main");
         assert_eq!(target_rev, "@");
+        assert!(!is_inclusive);
+
+        // Test inclusive range (::) operator
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
+            parse_revision_and_range(Some("main::@"), false, None).unwrap();
+
+        assert!(use_range_mode);
+        assert_eq!(base_rev, "main");
+        assert_eq!(target_rev, "@");
+        assert!(is_inclusive);
     }
 
     #[test]
     fn test_all_mode_with_default_revision() {
         // Test that --all mode works with default revision
-        let (use_range_mode, base_rev, target_rev) =
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(None, true, None).unwrap();
 
         assert!(use_range_mode);
         assert_eq!(base_rev, "trunk()");
         assert_eq!(target_rev, "@-");
+        assert!(!is_inclusive);
     }
 
     #[test]
     fn test_all_mode_with_custom_base() {
         // Test that --all mode works with custom base
-        let (use_range_mode, base_rev, target_rev) =
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(None, true, Some("main")).unwrap();
 
         assert!(use_range_mode);
         assert_eq!(base_rev, "main");
         assert_eq!(target_rev, "@-");
+        assert!(!is_inclusive);
     }
 
     #[test]
@@ -106,11 +136,23 @@ mod tests {
     #[test]
     fn test_range_overrides_all_mode() {
         // Test that when both range syntax and --all are specified, range takes precedence
-        let (use_range_mode, base_rev, target_rev) =
+
+        // Test exclusive range (..) overrides --all mode
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
             parse_revision_and_range(Some("feature..@"), true, Some("trunk()")).unwrap();
 
         assert!(use_range_mode);
         assert_eq!(base_rev, "feature");
         assert_eq!(target_rev, "@");
+        assert!(!is_inclusive);
+
+        // Test inclusive range (::) overrides --all mode
+        let (use_range_mode, base_rev, target_rev, is_inclusive) =
+            parse_revision_and_range(Some("feature::@"), true, Some("trunk()")).unwrap();
+
+        assert!(use_range_mode);
+        assert_eq!(base_rev, "feature");
+        assert_eq!(target_rev, "@");
+        assert!(is_inclusive);
     }
 }


### PR DESCRIPTION
This PR contains 2 major changes:
- Fixes the ordering in which PRs are created by `jj-spr diff -a`. It was going through the changes reversed.
- Adds :: range operator support.