### PR TITLE
Allow `diff` and `land` even if the working copy has changes

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -60,9 +60,6 @@ pub async fn diff(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
-    // Abort right here if the local Jujutsu repository is not clean
-    jj.check_no_uncommitted_changes()?;
-
     let mut result = Ok(());
 
     // Determine revision and whether to use range mode

--- a/spr/src/commands/land.rs
+++ b/spr/src/commands/land.rs
@@ -34,8 +34,6 @@ pub async fn land(
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
 ) -> Result<()> {
-    jj.check_no_uncommitted_changes()?;
-
     let revision = opts.revision.as_deref().unwrap_or("@");
     let prepared_commit = jj.get_prepared_commit_for_revision(config, revision)?;
 


### PR DESCRIPTION
Since we're using Jujutsu, the working copy is never dirty, and so the check for uncommitted changes is unnecessary.

I've been running with this patch for a few weeks now and haven't noticed any regressions. I'm not sure how to formally test it, though.