### PR TITLE
docs: Add hyperlink to example log template

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -127,11 +127,17 @@ push-branch-prefix = "jj-spr/"
 label(if(current_working_copy, "bold"),
   concat(
     separate(" ",
-      label("cyan", change_id.shortest(8)),
-      label("magenta", if(description, description.first_line(), "(no description)"))
-    ),
-    if(description.regex("Pull Request: .*(#\\d+)"),
-      label("green", " " ++ description.regex("Pull Request: .*(#\\d+)")))
+      label("change_id", change_id.shortest(8)),
+      label("description", if(description, description.first_line(), "(no description)")),
+      if(!immutable,
+         description.lines()
+           .filter(|d| d.match(regex:'^Pull Request: https://.+/pull/(\d+)$'))
+           .map(|d| hyperlink(
+             d.remove_prefix("Pull Request: "),
+             label("bookmark",
+               d.replace(regex:'.*/pull/(\d+)$', '#$1')
+             ))))
+    )
   )
 )
 '''


### PR DESCRIPTION
The existing example has a few issues:

- The function `description.regex()` doesn't exist, it should be `description.match(regex:'...')`.

- Labels like "cyan", "magenta", etc. don't produce colored output becuase the default labels defined are things like "change_id", "bookmark", etc.

- Since we have the URL in the description, it's nice to make a hyperlink to the pull request.

So this example template:

- Renders pull requests as just the number: "#176"
- Creates a hyperlink to the pull request.
- Uses labels that Jujutsu defines by default.
- Only displays on commits which are mutable.