### PR TITLE
fix: add leading slash in GitHub API routes called via octocrab

### DIFF
--- a/spr/src/commands/init.rs
+++ b/spr/src/commands/init.rs
@@ -155,7 +155,7 @@ pub async fn init() -> Result<()> {
     // Master branch name (just query GitHub)
 
     let github_repo_info = octocrab
-        .get::<octocrab::models::Repository, _, _>(format!("repos/{}", &github_repo), None::<&()>)
+        .get::<octocrab::models::Repository, _, _>(format!("/repos/{}", &github_repo), None::<&()>)
         .await?;
 
     set_jj_config(

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -129,7 +129,7 @@ impl GitHub {
 
     pub async fn get_github_user(login: String) -> Result<UserWithName> {
         octocrab::instance()
-            .get::<UserWithName, _, _>(format!("users/{}", login), None::<&()>)
+            .get::<UserWithName, _, _>(format!("/users/{}", login), None::<&()>)
             .await
             .map_err(Error::from)
     }
@@ -373,7 +373,7 @@ impl GitHub {
         octocrab::instance()
             .patch::<octocrab::models::pulls::PullRequest, _, _>(
                 format!(
-                    "repos/{}/{}/pulls/{}",
+                    "/repos/{}/{}/pulls/{}",
                     self.config.owner, self.config.repo, number
                 ),
                 Some(&updates),
@@ -393,7 +393,7 @@ impl GitHub {
         let _: Ignore = octocrab::instance()
             .post(
                 format!(
-                    "repos/{}/{}/pulls/{}/requested_reviewers",
+                    "/repos/{}/{}/pulls/{}/requested_reviewers",
                     self.config.owner, self.config.repo, number
                 ),
                 Some(&reviewers),


### PR DESCRIPTION
As part of 9c49a86, `octocrab` was upgraded. The helper functions for the HTTP API in the new versions have the following behavior,
- The route we pass goes through a `parameterized_uri` function. https://github.com/XAMPPRocky/octocrab/blob/9fc79f7befa644d3caf572799bd4f1ac427dae9d/src/lib.rs#L1521
- The `parameterized_uri` function breaks when the string it's trying to parse doesn't have a leading slash. [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=c2b061db8d3200333ac7c76e3753337f)

How to reproduce the issue,
- make a change and run `jj spr diff`
- update the description of the change revision
- run `jj spr diff --update-message`

The command fails with a `Uri` error which is actually a `InvalidUri(InvalidFormat)` error. The same operation runs successfully after this change.

Tests,
```
❯ cargo test -q

running 56 tests
...
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.98s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.78s


running 12 tests
............
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.48s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.56s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.77s


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.94s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

❯ cargo test --test '*' --quiet

running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s


running 12 tests
............
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s


running 2 tests
..
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s


running 3 tests
...
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.75s
```