### PR TITLE
deps: update octocrab requirement from ^0.48.0 to ^0.48.1 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c4c16af97628682471056f83897a89e84238cc422a2af37c367acb3206a4b8"
+checksum = "c5930b376c98c438a4f4259a760cda2c198efea3b82de8f8a2aff0c00a8b7c1c"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -25,7 +25,7 @@ git2-ext = "0.6.0"
 graphql_client = "^0.14.0"
 indoc = "^2.0.6"
 lazy-regex = "^3.4.1"
-octocrab = { version = "^0.48.0", default-features = false, features = ["rustls", "rustls-ring", "default-client"] }
+octocrab = { version = "^0.48.1", default-features = false, features = ["rustls", "rustls-ring", "default-client"] }
 reqwest = { version = "^0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = "^1.0.136"
 textwrap = "0.16.2"


### PR DESCRIPTION
Fixes Nix build failure caused by octocrab 0.48.0's build.rs attempting to run cargo metadata in the vendored environment. Version 0.48.1 resolves this issue.

- Updated spr/Cargo.toml to require ^0.48.1
- Ran `cargo update octocrab` to update Cargo.lock and related dependencies