### PR TITLE
Fix template expression for jj version 0.36.0

### DIFF
--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -125,8 +125,8 @@ label(if(current_working_copy, "bold"),
       label("cyan", change_id.shortest(8)),
       label("magenta", if(description, description.first_line(), "(no description)"))
     ),
-    if(description.regex("Pull Request: .*(#\\d+)"),
-      label("green", " " ++ description.regex("Pull Request: .*(#\\d+)")))
+    if(description.match("Pull Request: .*(#\\d+)"),
+      label("green", " " ++ description.match("Pull Request: .*(#\\d+)")))
   )
 )
 '''


### PR DESCRIPTION
The previous template produced this error
```
jj log
Error: Failed to parse template: Method `regex` doesn't exist for type `String`
Caused by:  --> 8:41
  |
8 |       label("green", " " ++ description.regex("Pull Request: .*(#\\d+)")))
  |                                         ^---^
  |
  = Method `regex` doesn't exist for type `String`
```

but the new version works
```
jj log -r 'trunk()::@'
@  qxpymsnw Fix template expression for jj version 0.36.0
◆  wnqzozyn fix: add leading slash in GitHub API routes called via octocrab (#69)
```
