### PR TITLE
feat: add jj spr cleanup command

### DIFF
--- a/spr/src/commands/cleanup.rs
+++ b/spr/src/commands/cleanup.rs
@@ -8,10 +8,7 @@
 use std::collections::HashSet;
 use std::process::Stdio;
 
-use crate::{
-    error::Result,
-    output::output,
-};
+use crate::{error::Result, output::output};
 
 #[derive(Debug, clap::Parser)]
 pub struct CleanupOptions {
@@ -96,10 +93,7 @@ pub async fn cleanup(
     }
 
     if !opts.confirm {
-        output(
-            "💡",
-            "Run with --confirm to delete these branches.",
-        )?;
+        output("💡", "Run with --confirm to delete these branches.")?;
         return Ok(());
     }
 
@@ -123,7 +117,10 @@ pub async fn cleanup(
                 output("✅", &format!("Deleted {}", branch))?;
             }
             _ => {
-                output("⚠️", &format!("Failed to delete {} (may already be gone)", branch))?;
+                output(
+                    "⚠️",
+                    &format!("Failed to delete {} (may already be gone)", branch),
+                )?;
             }
         }
     }
@@ -160,13 +157,10 @@ mod tests {
 
     #[test]
     fn test_extract_spr_branch_names_empty_when_no_match() {
-        let refs: HashSet<String> = [
-            "refs/remotes/origin/main",
-            "refs/remotes/origin/feature",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+        let refs: HashSet<String> = ["refs/remotes/origin/main", "refs/remotes/origin/feature"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         let branches = extract_spr_branch_names(&refs, "origin", "spr/user/");
         assert!(branches.is_empty());
@@ -195,13 +189,10 @@ mod tests {
             "spr/user/feat-c".into(),
         ];
 
-        let open_pr_branches: HashSet<String> = [
-            "spr/user/feat-a",
-            "spr/user/main.feat-a",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+        let open_pr_branches: HashSet<String> = ["spr/user/feat-a", "spr/user/main.feat-a"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         let mut orphans: Vec<&str> = find_orphan_branches(&spr_branches, &open_pr_branches)
             .into_iter()
@@ -214,18 +205,13 @@ mod tests {
 
     #[test]
     fn test_find_orphan_branches_none_when_all_active() {
-        let spr_branches: Vec<String> = vec![
-            "spr/user/feat-a".into(),
-            "spr/user/main.feat-a".into(),
-        ];
+        let spr_branches: Vec<String> =
+            vec!["spr/user/feat-a".into(), "spr/user/main.feat-a".into()];
 
-        let open_pr_branches: HashSet<String> = [
-            "spr/user/feat-a",
-            "spr/user/main.feat-a",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+        let open_pr_branches: HashSet<String> = ["spr/user/feat-a", "spr/user/main.feat-a"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         let orphans = find_orphan_branches(&spr_branches, &open_pr_branches);
         assert!(orphans.is_empty());
@@ -233,10 +219,7 @@ mod tests {
 
     #[test]
     fn test_find_orphan_branches_all_orphans_when_no_open_prs() {
-        let spr_branches: Vec<String> = vec![
-            "spr/user/feat-a".into(),
-            "spr/user/feat-b".into(),
-        ];
+        let spr_branches: Vec<String> = vec!["spr/user/feat-a".into(), "spr/user/feat-b".into()];
 
         let open_pr_branches: HashSet<String> = HashSet::new();
 

--- a/spr/src/commands/cleanup.rs
+++ b/spr/src/commands/cleanup.rs
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Radical HQ Limited
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashSet;
+use std::process::Stdio;
+
+use crate::{
+    error::Result,
+    output::output,
+};
+
+#[derive(Debug, clap::Parser)]
+pub struct CleanupOptions {
+    /// Actually delete the orphan branches (default is list-only)
+    #[clap(long)]
+    confirm: bool,
+}
+
+/// Extract branch names from refs that match the SPR remote prefix.
+///
+/// Given refs like `refs/remotes/origin/spr/user/my-feature`, extracts
+/// `spr/user/my-feature`.
+fn extract_spr_branch_names(
+    all_refs: &HashSet<String>,
+    remote_name: &str,
+    branch_prefix: &str,
+) -> Vec<String> {
+    let remote_prefix = format!("refs/remotes/{}/{}", remote_name, branch_prefix);
+    let strip_len = "refs/remotes/".len() + remote_name.len() + 1;
+
+    all_refs
+        .iter()
+        .filter(|r| r.starts_with(&remote_prefix))
+        .map(|r| r[strip_len..].to_string())
+        .collect()
+}
+
+/// Find SPR branches that are not referenced by any open PR.
+fn find_orphan_branches<'a>(
+    spr_branches: &'a [String],
+    open_pr_branches: &HashSet<String>,
+) -> Vec<&'a String> {
+    spr_branches
+        .iter()
+        .filter(|b| !open_pr_branches.contains(*b))
+        .collect()
+}
+
+pub async fn cleanup(
+    opts: CleanupOptions,
+    jj: &crate::jj::Jujutsu,
+    gh: &crate::github::GitHub,
+    config: &crate::config::Config,
+) -> Result<()> {
+    output("🔍", "Finding orphan SPR branches...")?;
+
+    let all_refs = jj.get_all_ref_names()?;
+    let spr_branches =
+        extract_spr_branch_names(&all_refs, &config.remote_name, &config.branch_prefix);
+
+    if spr_branches.is_empty() {
+        output("✨", "No SPR branches found. Nothing to clean up.")?;
+        return Ok(());
+    }
+
+    let open_pr_branches = gh.get_open_pr_branch_names().await?;
+    let orphan_branches = find_orphan_branches(&spr_branches, &open_pr_branches);
+
+    if orphan_branches.is_empty() {
+        output(
+            "✨",
+            &format!(
+                "All {} SPR branch(es) belong to open PRs. Nothing to clean up.",
+                spr_branches.len()
+            ),
+        )?;
+        return Ok(());
+    }
+
+    output(
+        "🗑️",
+        &format!(
+            "Found {} orphan SPR branch(es) (out of {} total):",
+            orphan_branches.len(),
+            spr_branches.len()
+        ),
+    )?;
+
+    let term = console::Term::stdout();
+    for branch in &orphan_branches {
+        term.write_line(&format!("     {}", console::style(*branch).dim()))?;
+    }
+
+    if !opts.confirm {
+        output(
+            "💡",
+            "Run with --confirm to delete these branches.",
+        )?;
+        return Ok(());
+    }
+
+    output("🧹", "Deleting orphan branches...")?;
+
+    for branch in &orphan_branches {
+        let result = tokio::process::Command::new("git")
+            .arg("push")
+            .arg("--no-verify")
+            .arg("--delete")
+            .arg("--")
+            .arg(&config.remote_name)
+            .arg(format!("refs/heads/{}", branch))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .await;
+
+        match result {
+            Ok(status) if status.status.success() => {
+                output("✅", &format!("Deleted {}", branch))?;
+            }
+            _ => {
+                output("⚠️", &format!("Failed to delete {} (may already be gone)", branch))?;
+            }
+        }
+    }
+
+    output("✨", "Cleanup complete.")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_spr_branch_names_filters_by_prefix() {
+        let refs: HashSet<String> = [
+            "refs/remotes/origin/spr/user/my-feature",
+            "refs/remotes/origin/spr/user/main.my-feature",
+            "refs/remotes/origin/main",
+            "refs/remotes/origin/other-branch",
+            "refs/heads/local-branch",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let mut branches = extract_spr_branch_names(&refs, "origin", "spr/user/");
+        branches.sort();
+
+        assert_eq!(
+            branches,
+            vec!["spr/user/main.my-feature", "spr/user/my-feature"]
+        );
+    }
+
+    #[test]
+    fn test_extract_spr_branch_names_empty_when_no_match() {
+        let refs: HashSet<String> = [
+            "refs/remotes/origin/main",
+            "refs/remotes/origin/feature",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let branches = extract_spr_branch_names(&refs, "origin", "spr/user/");
+        assert!(branches.is_empty());
+    }
+
+    #[test]
+    fn test_extract_spr_branch_names_respects_remote_name() {
+        let refs: HashSet<String> = [
+            "refs/remotes/origin/spr/user/feat",
+            "refs/remotes/upstream/spr/user/feat",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let branches = extract_spr_branch_names(&refs, "upstream", "spr/user/");
+        assert_eq!(branches, vec!["spr/user/feat"]);
+    }
+
+    #[test]
+    fn test_find_orphan_branches_identifies_orphans() {
+        let spr_branches: Vec<String> = vec![
+            "spr/user/feat-a".into(),
+            "spr/user/main.feat-a".into(),
+            "spr/user/feat-b".into(),
+            "spr/user/feat-c".into(),
+        ];
+
+        let open_pr_branches: HashSet<String> = [
+            "spr/user/feat-a",
+            "spr/user/main.feat-a",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let mut orphans: Vec<&str> = find_orphan_branches(&spr_branches, &open_pr_branches)
+            .into_iter()
+            .map(|s| s.as_str())
+            .collect();
+        orphans.sort();
+
+        assert_eq!(orphans, vec!["spr/user/feat-b", "spr/user/feat-c"]);
+    }
+
+    #[test]
+    fn test_find_orphan_branches_none_when_all_active() {
+        let spr_branches: Vec<String> = vec![
+            "spr/user/feat-a".into(),
+            "spr/user/main.feat-a".into(),
+        ];
+
+        let open_pr_branches: HashSet<String> = [
+            "spr/user/feat-a",
+            "spr/user/main.feat-a",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let orphans = find_orphan_branches(&spr_branches, &open_pr_branches);
+        assert!(orphans.is_empty());
+    }
+
+    #[test]
+    fn test_find_orphan_branches_all_orphans_when_no_open_prs() {
+        let spr_branches: Vec<String> = vec![
+            "spr/user/feat-a".into(),
+            "spr/user/feat-b".into(),
+        ];
+
+        let open_pr_branches: HashSet<String> = HashSet::new();
+
+        let orphans = find_orphan_branches(&spr_branches, &open_pr_branches);
+        assert_eq!(orphans.len(), 2);
+    }
+}

--- a/spr/src/commands/mod.rs
+++ b/spr/src/commands/mod.rs
@@ -6,6 +6,7 @@
  */
 
 pub mod amend;
+pub mod cleanup;
 pub mod close;
 pub mod diff;
 pub mod format;

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -484,9 +484,7 @@ impl GitHub {
                 res.json().await?;
 
             if let Some(errors) = response_body.errors {
-                let error = Err(Error::new(
-                    "fetching open PR branches failed".to_string(),
-                ));
+                let error = Err(Error::new("fetching open PR branches failed".to_string()));
                 return errors
                     .into_iter()
                     .fold(error, |err, e| err.context(e.to_string()));

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -119,6 +119,14 @@ type GitObjectID = String;
 )]
 pub struct PullRequestMergeabilityQuery;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.docs.graphql",
+    query_path = "src/gql/open_pull_request_branches.graphql",
+    response_derives = "Debug"
+)]
+pub struct OpenPullRequestBranchesQuery;
+
 impl GitHub {
     pub fn new(config: crate::config::Config, graphql_client: reqwest::Client) -> Self {
         Self {
@@ -452,6 +460,60 @@ impl GitHub {
                 .merge_commit
                 .and_then(|sha| git2::Oid::from_str(&sha.oid).ok()),
         })
+    }
+
+    pub async fn get_open_pr_branch_names(&self) -> Result<HashSet<String>> {
+        let mut branch_names = HashSet::new();
+        let mut after: Option<String> = None;
+
+        loop {
+            let variables = open_pull_request_branches_query::Variables {
+                owner: self.config.owner.clone(),
+                name: self.config.repo.clone(),
+                first: 100,
+                after: after.clone(),
+            };
+            let request_body = OpenPullRequestBranchesQuery::build_query(variables);
+            let res = self
+                .graphql_client
+                .post("https://api.github.com/graphql")
+                .json(&request_body)
+                .send()
+                .await?;
+            let response_body: Response<open_pull_request_branches_query::ResponseData> =
+                res.json().await?;
+
+            if let Some(errors) = response_body.errors {
+                let error = Err(Error::new(
+                    "fetching open PR branches failed".to_string(),
+                ));
+                return errors
+                    .into_iter()
+                    .fold(error, |err, e| err.context(e.to_string()));
+            }
+
+            let prs = response_body
+                .data
+                .ok_or_else(|| Error::new("failed to fetch open PRs"))?
+                .repository
+                .ok_or_else(|| Error::new("failed to find repository"))?
+                .pull_requests;
+
+            if let Some(nodes) = prs.nodes {
+                for node in nodes.into_iter().flatten() {
+                    branch_names.insert(node.head_ref_name);
+                    branch_names.insert(node.base_ref_name);
+                }
+            }
+
+            if prs.page_info.has_next_page {
+                after = prs.page_info.end_cursor;
+            } else {
+                break;
+            }
+        }
+
+        Ok(branch_names)
     }
 }
 

--- a/spr/src/gql/open_pull_request_branches.graphql
+++ b/spr/src/gql/open_pull_request_branches.graphql
@@ -1,0 +1,15 @@
+query OpenPullRequestBranchesQuery($owner: String!, $name: String!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: [OPEN], first: $first, after: $after) {
+      nodes {
+        number
+        headRefName
+        baseRefName
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -72,6 +72,9 @@ enum Commands {
 
     /// Close a Pull request
     Close(commands::close::CloseOptions),
+
+    /// Remove orphan SPR branches from the remote
+    Cleanup(commands::cleanup::CleanupOptions),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -196,6 +199,7 @@ pub async fn spr() -> Result<()> {
         Commands::List => commands::list::list(graphql_client, &config).await?,
         Commands::Patch(opts) => commands::patch::patch(opts, &jj, &mut gh, &config).await?,
         Commands::Close(opts) => commands::close::close(opts, &jj, &mut gh, &config).await?,
+        Commands::Cleanup(opts) => commands::cleanup::cleanup(opts, &jj, &gh, &config).await?,
         // The following commands are executed above and return from this
         // function before it reaches this match.
         Commands::Init | Commands::Format(_) => (),


### PR DESCRIPTION
## Summary

- New `jj spr cleanup` command that finds and deletes orphan SPR branches on the remote
- Queries GitHub GraphQL API for open PR branches, compares against remote refs to identify orphans
- Dry-run by default (lists orphans), `--confirm` flag to actually delete
- Includes GraphQL query with pagination, new `get_open_pr_branch_names()` GitHub method
- 6 unit tests for branch extraction and orphan filtering logic

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [ ] Run `jj spr cleanup` to list orphan branches
- [ ] Run `jj spr cleanup --confirm` to delete them
- [ ] Verify with `git branch -r | grep spr/` that orphans are gone