### PR TITLE
Add draft and checks status to `jj spr list` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +97,12 @@ checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
@@ -149,6 +174,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -552,6 +583,12 @@ name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1123,6 +1160,7 @@ dependencies = [
  "octocrab",
  "reqwest",
  "serde",
+ "tabled",
  "tempfile",
  "textwrap",
  "thiserror 2.0.17",
@@ -1272,6 +1310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1324,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1425,6 +1479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1612,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2196,6 +2285,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2636,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -28,6 +28,7 @@ lazy-regex = "^3.4.1"
 octocrab = { version = "^0.48.0", default-features = false, features = ["rustls", "rustls-ring", "default-client"] }
 reqwest = { version = "^0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde = "^1.0.136"
+tabled = { version = "0.17", features = ["ansi"] }
 textwrap = "0.16.2"
 thiserror = "^2.0.17"
 tokio = { version = "^1.19.2", features = ["macros", "process", "rt-multi-thread", "time"] }

--- a/spr/src/commands/list.rs
+++ b/spr/src/commands/list.rs
@@ -9,6 +9,9 @@ use crate::error::Error;
 use crate::error::Result;
 use graphql_client::{GraphQLQuery, Response};
 use reqwest;
+use tabled::Table;
+use tabled::Tabled;
+use tabled::settings::Style;
 
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;
@@ -38,8 +41,17 @@ pub async fn list(graphql_client: reqwest::Client, config: &crate::config::Confi
     print_pr_info(response_body).ok_or_else(|| Error::new("unexpected error"))
 }
 
+#[derive(Tabled)]
+struct Row {
+    #[tabled(rename = "Reviews")]
+    review_status: String,
+    #[tabled(rename = "Description")]
+    description: String,
+}
+
 fn print_pr_info(response_body: Response<search_query::ResponseData>) -> Option<()> {
-    let term = console::Term::stdout();
+    let mut rows: Vec<Row> = Vec::new();
+
     for pr in response_body.data?.search.nodes? {
         let pr = match pr {
             Some(crate::commands::list::search_query::SearchQuerySearchNodes::PullRequest(pr)) => {
@@ -47,29 +59,41 @@ fn print_pr_info(response_body: Response<search_query::ResponseData>) -> Option<
             }
             _ => continue,
         };
-        let dummy: String;
-        let decision = match pr.review_decision {
+
+        let review_status = match pr.review_decision {
             Some(search_query::PullRequestReviewDecision::APPROVED) => {
-                console::style("Accepted").green()
+                console::style("Accepted").green().to_string()
             }
             Some(search_query::PullRequestReviewDecision::CHANGES_REQUESTED) => {
-                console::style("Changes Requested").red()
+                console::style("Changes Requested").red().to_string()
             }
             None | Some(search_query::PullRequestReviewDecision::REVIEW_REQUIRED) => {
-                console::style("Pending")
+                "Pending".to_string()
             }
-            Some(search_query::PullRequestReviewDecision::Other(d)) => {
-                dummy = d;
-                console::style(dummy.as_str())
-            }
+            Some(search_query::PullRequestReviewDecision::Other(d)) => d,
         };
-        term.write_line(&format!(
-            "{} {} {}",
-            decision,
+
+        let description = format!(
+            "{}\n{}",
             console::style(&pr.title).bold(),
             console::style(&pr.url).dim(),
-        ))
-        .ok()?;
+        );
+
+        rows.push(Row {
+            review_status,
+            description,
+        });
     }
+
+    if rows.is_empty() {
+        return Some(());
+    }
+
+    let mut table = Table::new(rows);
+    table.with(Style::sharp());
+
+    let term = console::Term::stdout();
+    term.write_line(&table.to_string()).ok()?;
+
     Some(())
 }


### PR DESCRIPTION
Adds two new fields showing:

- If a PR is in draft status (pencil icon for draft, page for published)
- Whether all checks on a pull request have passed, any have failed, or
  if the result is still pending.

The output looks like this:

```
$ jj spr list
┌─────────┬─────────┬────────────────────────────────────────────────┐
│ Reviews │ Checks  │ Description                                    │
├─────────┼─────────┼────────────────────────────────────────────────┤
│ Pending │ Pending │ 📄 Display `list` output as a table            │
│         │         │ https://github.com/LucioFranco/jj-spr/pull/113 │
└─────────┴─────────┴────────────────────────────────────────────────┘
```
