### PR TITLE
set home directory for jj v38+ in nix derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,11 @@
                 jujutsu
               ];
 
+              preCheck = ''
+                export HOME="$TMPDIR/home"
+                mkdir -p $HOME
+              '';
+
               meta = with pkgs.lib; {
                 description = "Jujutsu subcommand for submitting pull requests for individual, amendable, rebaseable commits to GitHub";
                 homepage = "https://github.com/LucioFranco/spr";


### PR DESCRIPTION
Nix derivation fails to build with latest nixpkgs because Jujutsu 0.38 changed how repo config is stored. It is now stored in the home directory, and so the derivation needed a mutable home (located at TMPDIR/home with this PR) to be able to run tests.

Fixes #97