### PR TITLE
fix: use real commit message for initial PR branch commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - jj-spr now works in workspaces that aren't colocated.
+- The first commit in a pull reuqest now uses the local commit's description.
 
 ## [0.1.0] - 2025-11-15
 

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -605,7 +605,7 @@ async fn diff_impl(
                 github_commit_message
                     .as_ref()
                     .map(|s| &s[..])
-                    .unwrap_or("[jj-spr] initial version"),
+                    .unwrap_or_else(|| title),
                 env!("CARGO_PKG_VERSION"),
             ),
             new_head_tree,


### PR DESCRIPTION
## Summary
- When creating a new PR with `jj spr diff`, the git commit pushed to the PR branch uses the hardcoded string `[jj-spr] initial version` instead of the actual commit title
- The GitHub PR title/body are already correct (taken from the commit message); this only affects the git commit on the PR branch
- One-line fix: use the parsed commit title as the fallback instead of the hardcoded string

## Test plan
- [x] All existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)