### PR TITLE
Add support for non-colocated workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- jj-spr now works in workspaces that aren't colocated.
+
 ## [0.1.0] - 2025-11-15
 
 ### Added
+
 - Initial release of Super Pull Requests (SPR)
 - Power tool for Jujutsu + GitHub workflows
 - Amend-friendly single PR workflow: Amend freely in jj, review cleanly on GitHub
@@ -23,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation and guides
 
 ### Changed
+
 - Rebranded from "jj-spr (Jujutsu Stacked Pull Requests)" to "Super Pull Requests"
 - Version reset to 0.1.0 for official release
 - Updated project metadata and repository information

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,18 +22,18 @@ dependencies = [
 
 [[package]]
 name = "ansi-str"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
 dependencies = [
  "ansitok",
 ]
 
 [[package]]
 name = "ansitok"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
  "nom",
  "vte",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -2286,27 +2286,28 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "ansi-str",
  "ansitok",
  "papergrid",
  "tabled_derive",
+ "testing_table",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2330,6 +2331,16 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "ansitok",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2639,23 +2650,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]

--- a/spr/src/commands/amend.rs
+++ b/spr/src/commands/amend.rs
@@ -66,7 +66,7 @@ pub async fn amend(
 
     let mut failure = false;
 
-    for (commit, pull_request) in pc.iter_mut().zip(pull_requests.into_iter()) {
+    for (commit, pull_request) in pc.iter_mut().zip(pull_requests) {
         write_commit_title(commit)?;
         if let Some(pull_request) = pull_request {
             let pull_request = pull_request.await??;

--- a/spr/src/commands/close.rs
+++ b/spr/src/commands/close.rs
@@ -71,7 +71,7 @@ pub async fn close(
         // This makes it easier to run the code to update the local commit message
         // with all the changes that the implementation makes at the end, even if
         // the implementation encounters an error or exits early.
-        result = close_impl(gh, config, prepared_commit).await;
+        result = close_impl(jj, gh, config, prepared_commit).await;
     }
 
     // This updates the commit message in the local Jujutsu repository (if it was
@@ -85,6 +85,7 @@ pub async fn close(
 }
 
 async fn close_impl(
+    jj: &crate::jj::Jujutsu,
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
     prepared_commit: &mut PreparedCommit,
@@ -135,7 +136,8 @@ async fn close_impl(
     prepared_commit.message.remove(&MessageSection::ReviewedBy);
     prepared_commit.message_changed = true;
 
-    let mut remove_old_branch_child_process = tokio::process::Command::new("git")
+    let mut remove_old_branch_child_process = jj
+        .git_command()
         .arg("push")
         .arg("--no-verify")
         .arg("--delete")
@@ -150,7 +152,7 @@ async fn close_impl(
         None
     } else {
         Some(
-            tokio::process::Command::new("git")
+            jj.git_command()
                 .arg("push")
                 .arg("--no-verify")
                 .arg("--delete")

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -108,8 +108,7 @@ pub async fn diff(
 
     let mut message_on_prompt = "".to_string();
 
-    for (prepared_commit, pull_request_task) in
-        zip(prepared_commits.iter_mut(), pull_request_tasks.into_iter())
+    for (prepared_commit, pull_request_task) in zip(prepared_commits.iter_mut(), pull_request_tasks)
     {
         if result.is_err() {
             break;
@@ -642,7 +641,7 @@ async fn diff_impl(
             })
         };
     } else {
-        let mut cmd = tokio::process::Command::new("git");
+        let mut cmd = jj.git_command();
         cmd.arg("push")
             .arg("--atomic")
             .arg("--no-verify")

--- a/spr/src/commands/init.rs
+++ b/spr/src/commands/init.rs
@@ -18,12 +18,11 @@ pub async fn init() -> Result<()> {
     output("👋", "Welcome to spr!")?;
 
     let path = std::env::current_dir()?;
-    let repo = git2::Repository::discover(path.clone()).reword(formatdoc!(
-        "Could not open a Git repository in {:?}. Please run 'spr' from within \
-         a Git repository.",
-        path
+    let repo = crate::jj::Jujutsu::new(path.clone()).reword(formatdoc!(
+        "Could not find Git backend for Jujutsu repository in {:?}.",
+        &path
     ))?;
-    let config = repo.config()?;
+    let config = repo.git_repo.config()?;
 
     // GitHub Personal Access Token
 
@@ -132,7 +131,7 @@ pub async fn init() -> Result<()> {
         ),
     )?;
 
-    let url = repo.find_remote(&remote)?.url().map(String::from);
+    let url = repo.git_repo.find_remote(&remote)?.url().map(String::from);
     let regex = lazy_regex::regex!(r#"github\.com[/:]([\w\-\.]+/[\w\-\.]+?)(.git)?$"#);
     let github_repo = config
         .get_string("spr.githubRepository")

--- a/spr/src/commands/land.rs
+++ b/spr/src/commands/land.rs
@@ -68,7 +68,7 @@ pub async fn land(
 
     // Fetch current master from GitHub.
     run_command(
-        tokio::process::Command::new("git")
+        jj.git_command()
             .arg("fetch")
             .arg("--no-write-fetch-head")
             .arg("--")
@@ -253,7 +253,8 @@ pub async fn land(
 
     output("🛬", "Landed!")?;
 
-    let mut remove_old_branch_child_process = tokio::process::Command::new("git")
+    let mut remove_old_branch_child_process = jj
+        .git_command()
         .arg("push")
         .arg("--no-verify")
         .arg("--delete")
@@ -268,7 +269,7 @@ pub async fn land(
         None
     } else {
         Some(
-            tokio::process::Command::new("git")
+            jj.git_command()
                 .arg("push")
                 .arg("--no-verify")
                 .arg("--delete")
@@ -287,7 +288,8 @@ pub async fn land(
         // the merge might still not find the new commit.
         for i in 0..3 {
             // Fetch current master and the merge commit from GitHub.
-            let git_fetch = tokio::process::Command::new("git")
+            let git_fetch = jj
+                .git_command()
                 .arg("fetch")
                 .arg("--no-write-fetch-head")
                 .arg("--")

--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -12,11 +12,15 @@ use crate::{
     error::{Error, Result, ResultExt},
     message::{MessageSection, MessageSectionsMap, build_github_body, parse_message},
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 #[derive(Clone)]
 pub struct GitHub {
     config: crate::config::Config,
+    repo_path: PathBuf,
     graphql_client: reqwest::Client,
 }
 
@@ -120,9 +124,14 @@ type GitObjectID = String;
 pub struct PullRequestMergeabilityQuery;
 
 impl GitHub {
-    pub fn new(config: crate::config::Config, graphql_client: reqwest::Client) -> Self {
+    pub fn new(
+        config: crate::config::Config,
+        repo_path: PathBuf,
+        graphql_client: reqwest::Client,
+    ) -> Self {
         Self {
             config,
+            repo_path,
             graphql_client,
         }
     }
@@ -148,8 +157,10 @@ impl GitHub {
     pub async fn get_pull_request(self, number: u64) -> Result<PullRequest> {
         let GitHub {
             config,
+            repo_path,
             graphql_client,
         } = self;
+        let repo_path = repo_path.to_str().unwrap();
 
         let variables = pull_request_query::Variables {
             name: config.repo.clone(),
@@ -185,6 +196,8 @@ impl GitHub {
         // Fetch refs from remote using git (since we're in a colocated repo)
         let _fetch_result = tokio::process::Command::new("git")
             .args([
+                "--git-dir",
+                repo_path,
                 "fetch",
                 "--no-write-fetch-head",
                 &config.remote_name,
@@ -196,7 +209,7 @@ impl GitHub {
 
         // Convert branch refs to OIDs
         let base_oid = if let Ok(output) = tokio::process::Command::new("git")
-            .args(["rev-parse", base.local()])
+            .args(["--git-dir", repo_path, "rev-parse", base.local()])
             .output()
             .await
         {
@@ -211,7 +224,7 @@ impl GitHub {
         };
 
         let head_oid = if let Ok(output) = tokio::process::Command::new("git")
-            .args(["rev-parse", head.local()])
+            .args(["--git-dir", repo_path, "rev-parse", head.local()])
             .output()
             .await
         {

--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -7,7 +7,7 @@
 
 use std::{
     ffi::OsStr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -53,28 +53,23 @@ pub struct Jujutsu {
 }
 
 impl Jujutsu {
-    pub fn new(git_repo: git2::Repository) -> Result<Self> {
-        let repo_path = git_repo
-            .workdir()
-            .ok_or_else(|| Error::new("Repository must have a working directory".to_string()))?
-            .to_path_buf();
-
-        // Verify this is a Jujutsu repository
-        let jj_dir = repo_path.join(".jj");
-        if !jj_dir.exists() {
-            return Err(Error::new(
-                "This is not a Jujutsu repository. Run 'jj git init --colocate' to create one."
-                    .to_string(),
-            ));
-        }
-
+    pub fn new(current_path: PathBuf) -> Result<Self> {
         let jj_bin = get_jj_bin();
+        let workspace_root = discover_workspace_root(&jj_bin, &current_path)?;
+        let git_repo = find_git_repo(&workspace_root)?;
 
         Ok(Self {
-            repo_path,
+            repo_path: workspace_root,
             jj_bin,
             git_repo,
         })
+    }
+
+    pub fn git_command(&self) -> tokio::process::Command {
+        let git_repo_path = self.git_repo.path();
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.arg("--git-dir").arg(git_repo_path);
+        cmd
     }
 
     pub fn get_prepared_commit_for_revision(
@@ -87,8 +82,11 @@ impl Jujutsu {
     }
 
     pub fn get_master_base_for_commit(&self, config: &Config, commit_oid: Oid) -> Result<Oid> {
-        // Find the merge base between the commit and master
-        let master_oid = self.resolve_revision_to_commit_id(config.master_ref.local())?;
+        // Find the merge base between the commit and master.
+        // Use git2 to resolve the ref directly rather than jj CLI, since
+        // config.master_ref.local() returns a git ref path (e.g.
+        // "refs/remotes/origin/main") which is not a valid jj revset.
+        let master_oid = self.resolve_reference(config.master_ref.local())?;
         let merge_base = self.git_repo.merge_base(commit_oid, master_oid)?;
         Ok(merge_base)
     }
@@ -370,6 +368,86 @@ fn get_jj_bin() -> PathBuf {
     std::env::var_os("JJ").map_or_else(|| "jj".into(), |v| v.into())
 }
 
+/// Discover the Jujutsu workspace root from the given directory by running `jj root`.
+fn discover_workspace_root(jj_bin: &PathBuf, current_dir: &Path) -> Result<PathBuf> {
+    let output = Command::new(jj_bin)
+        .arg("root")
+        .current_dir(current_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("jj failed to spawn".to_string())?;
+
+    if output.status.success() {
+        let root = String::from_utf8(output.stdout)
+            .context("jj root output was not valid UTF-8".to_string())?;
+        Ok(PathBuf::from(root.trim()))
+    } else {
+        Err(Error::new(
+            "This command requires a Jujutsu repository. \
+                 Could not find a Jujutsu workspace in the current directory."
+                .to_string(),
+        ))
+    }
+}
+
+/// Resolve the `.jj/repo` path, handling the indirection used by non-default
+/// workspaces where `.jj/repo` is a file containing a relative path to the
+/// primary workspace's repo directory.
+fn resolve_repo_dir(workspace_root: &Path) -> Result<PathBuf> {
+    let repo_path = workspace_root.join(".jj").join("repo");
+    if repo_path.is_file() {
+        // Non-default workspace: .jj/repo is a file whose contents are a
+        // path (relative to .jj/) pointing to the actual repo directory.
+        let contents = std::fs::read(&repo_path)
+            .context("failed to read .jj/repo pointer file".to_string())?;
+        let relative = String::from_utf8(contents)
+            .context(".jj/repo pointer was not valid UTF-8".to_string())?;
+        let jj_dir = workspace_root.join(".jj");
+        jj_dir
+            .join(relative.trim())
+            .canonicalize()
+            .context("failed to resolve .jj/repo pointer".to_string())
+    } else {
+        Ok(repo_path)
+    }
+}
+
+/// Find the git2::Repository backing a Jujutsu workspace.
+///
+/// Supports colocated repos (`.git` at the workspace root), non-colocated
+/// repos (git backend inside `.jj/repo/store/`), and non-default workspaces
+/// (where `.jj/repo` is a pointer file).
+fn find_git_repo(workspace_root: &Path) -> Result<git2::Repository> {
+    // First try colocated: .git at the root
+    let dot_git = workspace_root.join(".git");
+    if dot_git.exists() {
+        return Ok(git2::Repository::open(workspace_root)?);
+    }
+
+    // Resolve .jj/repo (may be a file in non-default workspaces)
+    let repo_dir = resolve_repo_dir(workspace_root)?;
+    let store_dir = repo_dir.join("store");
+    let git_target_path = store_dir.join("git_target");
+    if git_target_path.exists() {
+        let git_target = std::fs::read_to_string(&git_target_path)
+            .context("failed to read .jj/repo/store/git_target".to_string())?;
+        let git_path = git_target.trim();
+        let git_path = if Path::new(git_path).is_absolute() {
+            PathBuf::from(git_path)
+        } else {
+            store_dir.join(git_path).canonicalize()?
+        };
+        return Ok(git2::Repository::open(&git_path)?);
+    }
+
+    Err(Error::new(
+        "Could not find Git backend for Jujutsu repository. \
+         Ensure you have a Jujutsu repository with a Git backend."
+            .to_string(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -454,9 +532,7 @@ mod tests {
     #[test]
     fn test_jujutsu_creation() {
         let (_temp_dir, repo_path) = create_jujutsu_test_repo();
-        let git_repo = git2::Repository::open(&repo_path).expect("Failed to open git repository");
-
-        let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
         assert!(jj.repo_path.exists());
         assert!(jj.repo_path.join(".jj").exists());
     }
@@ -470,8 +546,7 @@ mod tests {
         let _commit1 = create_jujutsu_commit(&repo_path, "First commit", "content1");
         let _commit2 = create_jujutsu_commit(&repo_path, "Second commit", "content2");
 
-        let git_repo = git2::Repository::open(&repo_path).expect("Failed to open git repository");
-        let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
 
         // Test resolving current revision (@)
         let result = jj.get_prepared_commit_for_revision(&config, "@");
@@ -500,8 +575,7 @@ mod tests {
         let _commit2 = create_jujutsu_commit(&repo_path, "Second commit", "content2");
         let _commit3 = create_jujutsu_commit(&repo_path, "Third commit", "content3");
 
-        let git_repo = git2::Repository::open(&repo_path).expect("Failed to open git repository");
-        let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
 
         // Test getting commit range
         let result = jj.get_prepared_commits_from_to(&config, "@----", "@-", false);
@@ -542,8 +616,7 @@ mod tests {
     fn test_status_check() {
         let (_temp_dir, repo_path) = create_jujutsu_test_repo();
 
-        let git_repo = git2::Repository::open(&repo_path).expect("Failed to open git repository");
-        let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
 
         // Should pass since new repo has no changes
         let result = jj.check_no_uncommitted_changes();
@@ -561,8 +634,7 @@ mod tests {
         // Create a commit with some content
         let _commit1 = create_jujutsu_commit(&repo_path, "Original commit", "original content");
 
-        let git_repo = git2::Repository::open(&repo_path).expect("Failed to open git repository");
-        let jj = Jujutsu::new(git_repo).expect("Failed to create Jujutsu instance");
+        let jj = Jujutsu::new(repo_path.clone()).expect("Failed to create Jujutsu instance");
 
         // Get the original commit
         let original_commit_oid = jj

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -87,24 +87,12 @@ pub async fn spr() -> Result<()> {
         return commands::init::init().await;
     }
 
-    // Discover the Jujutsu repository and get the colocated Git repo
+    // Discover the Jujutsu workspace root and find its Git backend
     let current_dir = std::env::current_dir()?;
-    let repo = git2::Repository::discover(&current_dir)?;
+    let jj = jj_spr::jj::Jujutsu::new(current_dir)
+        .context("could not initialize Jujutsu backend".to_owned())?;
 
-    // Verify this is a Jujutsu repository by checking for .jj directory
-    let repo_path = repo
-        .workdir()
-        .ok_or_else(|| Error::new("Repository must have a working directory".to_string()))?
-        .to_path_buf();
-
-    let jj_dir = repo_path.join(".jj");
-    if !jj_dir.exists() {
-        return Err(Error::new(
-            "This command requires a Jujutsu repository. Run 'jj git init --colocate' to create one.".to_string()
-        ));
-    }
-
-    let git_config = repo.config()?;
+    let git_config = jj.git_repo.config()?;
 
     // Try to get config from jj first, fall back to git config
     let github_repository = match cli.github_repository {
@@ -153,9 +141,6 @@ pub async fn spr() -> Result<()> {
         require_approval,
     );
 
-    let jj = jj_spr::jj::Jujutsu::new(repo)
-        .context("could not initialize Jujutsu backend".to_owned())?;
-
     if let Commands::Format(opts) = cli.command {
         return commands::format::format(opts, &jj, &config).await;
     }
@@ -187,7 +172,11 @@ pub async fn spr() -> Result<()> {
         .default_headers(headers)
         .build()?;
 
-    let mut gh = jj_spr::github::GitHub::new(config.clone(), graphql_client.clone());
+    let mut gh = jj_spr::github::GitHub::new(
+        config.clone(),
+        jj.git_repo.path().to_owned(),
+        graphql_client.clone(),
+    );
 
     match cli.command {
         Commands::Diff(opts) => commands::diff::diff(opts, &jj, &mut gh, &config).await?,


### PR DESCRIPTION
Add a helper `git_command()` that automatically adds the `--git-dir <path>` so commands will work even in a non-colocatd workspace.