### PR TITLE
Remember if PRs were opened as cherry-picks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - jj-spr now works in workspaces that aren't colocated.
 - The first commit in a pull reuqest now uses the local commit's description.
+- `jj spr diff` remembers when PRs were created as cherry picks so
+  `--cherry-pick` doesn't need to be specified each time the PR is updated.
 
 ## [0.1.0] - 2025-11-15
 

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -44,6 +44,12 @@ pub struct DiffOptions {
     #[clap(long)]
     cherry_pick: bool,
 
+    /// Remove the "Cherry Pick:" marker from the commit description and ignore
+    /// it for this invocation. Future `jj spr diff` invocations will behave
+    /// as though --cherry-pick was not specified.
+    #[clap(long, conflicts_with = "cherry_pick")]
+    no_cherry_pick: bool,
+
     /// Base revision for --all mode (if not specified, uses trunk)
     #[clap(long)]
     base: Option<String>,
@@ -56,6 +62,39 @@ pub struct DiffOptions {
     /// Preview what would happen without pushing or creating PRs
     #[clap(long)]
     pub dry_run: bool,
+}
+
+/// Resolve the effective cherry-pick state from CLI flags and the "Cherry Pick:"
+/// marker on the commit description.
+///
+/// When `--cherry-pick` is passed the marker is added (if absent); when
+/// `--no-cherry-pick` is passed the marker is removed (if present). Returns
+/// `(effective_cherry_pick, marker_was_changed)`.
+fn resolve_cherry_pick(
+    cherry_pick: bool,
+    no_cherry_pick: bool,
+    message: &mut crate::message::MessageSectionsMap,
+) -> (bool, bool) {
+    let stored = message
+        .get(&MessageSection::CherryPick)
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if no_cherry_pick {
+        if stored {
+            message.remove(&MessageSection::CherryPick);
+            return (false, true);
+        }
+        (false, false)
+    } else if cherry_pick {
+        if !stored {
+            message.insert(MessageSection::CherryPick, "true".to_string());
+            return (true, true);
+        }
+        (true, false)
+    } else {
+        (stored, false)
+    }
 }
 
 pub async fn diff(
@@ -233,12 +272,18 @@ async fn diff_impl(
     // Parsed commit message of the local commit
     let message = &mut local_commit.message;
 
+    let (effective_cherry_pick, marker_changed) =
+        resolve_cherry_pick(opts.cherry_pick, opts.no_cherry_pick, message);
+    if marker_changed {
+        local_commit.message_changed = true;
+    }
+
     // Check if the local commit is based directly on the master branch.
     let directly_based_on_master = local_commit.parent_oid == master_base_oid;
 
     // Determine the trees the Pull Request branch and the base branch should
     // have when we're done here.
-    let (new_head_tree, new_base_tree) = if !opts.cherry_pick || directly_based_on_master {
+    let (new_head_tree, new_base_tree) = if !effective_cherry_pick || directly_based_on_master {
         // Unless the user tells us to --cherry-pick, these should be the trees
         // of the current commit and its parent.
         // If the current commit is directly based on master (i.e.
@@ -501,7 +546,7 @@ async fn diff_impl(
     let (pr_base_parent, base_branch) = if pr_base_tree == new_base_tree && !needs_merging_master {
         // Case 1
         (None, base_branch)
-    } else if base_branch.is_none() && (directly_based_on_master || opts.cherry_pick) {
+    } else if base_branch.is_none() && (directly_based_on_master || effective_cherry_pick) {
         // Case 2
         (Some(master_base_oid), None)
     } else {
@@ -860,6 +905,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: None,
             revision: None,
             dry_run: false,
@@ -881,6 +927,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: Some("main".to_string()),
             revision: None,
             dry_run: false,
@@ -907,6 +954,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: Some("main".to_string()),
             revision: None,
             dry_run: false,
@@ -921,6 +969,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: Some("trunk()".to_string()),
             revision: None,
             dry_run: false,
@@ -937,6 +986,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: Some("trunk()".to_string()),
             revision: None,
             dry_run: false,
@@ -956,6 +1006,7 @@ mod tests {
             draft: true,
             message: Some("Update message".to_string()),
             cherry_pick: false,
+            no_cherry_pick: false,
             base: Some("trunk()".to_string()),
             revision: None,
             dry_run: false,
@@ -977,6 +1028,7 @@ mod tests {
             draft: false,
             message: None,
             cherry_pick: false,
+            no_cherry_pick: false,
             base: None,
             revision: None,
             dry_run: true,
@@ -984,6 +1036,105 @@ mod tests {
 
         assert!(opts.dry_run);
         assert!(!opts.all);
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve_cherry_pick unit tests
+
+    fn make_map_with_cherry_pick(value: &str) -> crate::message::MessageSectionsMap {
+        [(
+            crate::message::MessageSection::CherryPick,
+            value.to_string(),
+        )]
+        .into()
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_default_no_marker() {
+        let mut map = crate::message::MessageSectionsMap::new();
+        let (effective, changed) = resolve_cherry_pick(false, false, &mut map);
+        assert!(!effective);
+        assert!(!changed);
+        assert!(!map.contains_key(&crate::message::MessageSection::CherryPick));
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_default_with_marker() {
+        let mut map = make_map_with_cherry_pick("true");
+        let (effective, changed) = resolve_cherry_pick(false, false, &mut map);
+        assert!(effective);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_marker_case_insensitive() {
+        let mut map = make_map_with_cherry_pick("TRUE");
+        let (effective, _) = resolve_cherry_pick(false, false, &mut map);
+        assert!(effective);
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_marker_other_value() {
+        for value in &["false", "yes", "1", ""] {
+            let mut map = make_map_with_cherry_pick(value);
+            let (effective, _) = resolve_cherry_pick(false, false, &mut map);
+            assert!(!effective, "Expected false for marker value {:?}", value);
+        }
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_flag_inserts_marker() {
+        let mut map = crate::message::MessageSectionsMap::new();
+        let (effective, changed) = resolve_cherry_pick(true, false, &mut map);
+        assert!(effective);
+        assert!(changed);
+        assert_eq!(
+            map.get(&crate::message::MessageSection::CherryPick)
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_flag_idempotent() {
+        let mut map = make_map_with_cherry_pick("true");
+        let (effective, changed) = resolve_cherry_pick(true, false, &mut map);
+        assert!(effective);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_no_flag_removes_marker() {
+        let mut map = make_map_with_cherry_pick("true");
+        let (effective, changed) = resolve_cherry_pick(false, true, &mut map);
+        assert!(!effective);
+        assert!(changed);
+        assert!(!map.contains_key(&crate::message::MessageSection::CherryPick));
+    }
+
+    #[test]
+    fn test_resolve_cherry_pick_no_flag_when_absent() {
+        let mut map = crate::message::MessageSectionsMap::new();
+        let (effective, changed) = resolve_cherry_pick(false, true, &mut map);
+        assert!(!effective);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_diff_options_parse_no_cherry_pick() {
+        use clap::Parser;
+        let opts = DiffOptions::try_parse_from(["test", "--no-cherry-pick"]).unwrap();
+        assert!(opts.no_cherry_pick);
+        assert!(!opts.cherry_pick);
+    }
+
+    #[test]
+    fn test_diff_options_cherry_pick_no_cherry_pick_conflict() {
+        use clap::Parser;
+        let result = DiffOptions::try_parse_from(["test", "--cherry-pick", "--no-cherry-pick"]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     // Integration tests would require more complex setup with actual Git repositories

--- a/spr/src/commands/land.rs
+++ b/spr/src/commands/land.rs
@@ -11,7 +11,7 @@ use std::{io::Write, process::Stdio, time::Duration};
 use crate::{
     error::{Error, Result, ResultExt},
     github::{PullRequestState, PullRequestUpdate, ReviewStatus},
-    message::build_github_body_for_merging,
+    message::{MessageSection, build_github_body_for_merging},
     output::{output, write_commit_title},
     utils::run_command,
 };
@@ -28,8 +28,19 @@ pub struct LandOptions {
     revision: Option<String>,
 }
 
+fn resolve_cherry_pick(
+    cli_cherry_pick: bool,
+    message: &crate::message::MessageSectionsMap,
+) -> bool {
+    cli_cherry_pick
+        || message
+            .get(&MessageSection::CherryPick)
+            .map(|s| s.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+}
+
 pub async fn land(
-    opts: LandOptions,
+    mut opts: LandOptions,
     jj: &crate::jj::Jujutsu,
     gh: &mut crate::github::GitHub,
     config: &crate::config::Config,
@@ -37,8 +48,10 @@ pub async fn land(
     let revision = opts.revision.as_deref().unwrap_or("@");
     let prepared_commit = jj.get_prepared_commit_for_revision(config, revision)?;
 
-    // For Jujutsu, we'll determine if this is cherry-pick based on the revision's ancestry
-    // For now, we'll trust the user's --cherry-pick flag
+    // Honor both the --cherry-pick flag and the "Cherry Pick:" marker on the
+    // commit description. When the validation TODO below is filled in, use
+    // opts.cherry_pick as the authoritative source.
+    opts.cherry_pick = resolve_cherry_pick(opts.cherry_pick, &prepared_commit.message);
 
     write_commit_title(&prepared_commit)?;
 
@@ -324,4 +337,49 @@ pub async fn land(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_with_cherry_pick(value: &str) -> crate::message::MessageSectionsMap {
+        [(MessageSection::CherryPick, value.to_string())].into()
+    }
+
+    #[test]
+    fn test_land_resolve_flag_true() {
+        let map = crate::message::MessageSectionsMap::new();
+        assert!(resolve_cherry_pick(true, &map));
+    }
+
+    #[test]
+    fn test_land_resolve_flag_false_with_marker() {
+        let map = map_with_cherry_pick("true");
+        assert!(resolve_cherry_pick(false, &map));
+    }
+
+    #[test]
+    fn test_land_resolve_flag_false_without_marker() {
+        let map = crate::message::MessageSectionsMap::new();
+        assert!(!resolve_cherry_pick(false, &map));
+    }
+
+    #[test]
+    fn test_land_resolve_marker_case_insensitive() {
+        let map = map_with_cherry_pick("TRUE");
+        assert!(resolve_cherry_pick(false, &map));
+    }
+
+    #[test]
+    fn test_land_resolve_marker_other_value() {
+        for value in &["false", "yes", "1", ""] {
+            let map = map_with_cherry_pick(value);
+            assert!(
+                !resolve_cherry_pick(false, &map),
+                "Expected false for marker value {:?}",
+                value
+            );
+        }
+    }
 }

--- a/spr/src/message.rs
+++ b/spr/src/message.rs
@@ -19,6 +19,7 @@ pub enum MessageSection {
     Reviewers,
     ReviewedBy,
     PullRequest,
+    CherryPick,
 }
 
 pub fn message_section_label(section: &MessageSection) -> &'static str {
@@ -30,6 +31,7 @@ pub fn message_section_label(section: &MessageSection) -> &'static str {
         Reviewers => "Reviewers",
         ReviewedBy => "Reviewed By",
         PullRequest => "Pull Request",
+        CherryPick => "Cherry Pick",
     }
 }
 
@@ -43,6 +45,7 @@ pub fn message_section_by_label(label: &str) -> Option<MessageSection> {
         "reviewers" => Some(Reviewers),
         "reviewed by" => Some(ReviewedBy),
         "pull request" => Some(PullRequest),
+        "cherry pick" => Some(CherryPick),
         _ => None,
     }
 }
@@ -153,6 +156,7 @@ pub fn build_commit_message(section_texts: &MessageSectionsMap) -> String {
             MessageSection::Reviewers,
             MessageSection::ReviewedBy,
             MessageSection::PullRequest,
+            MessageSection::CherryPick,
         ],
     )
 }
@@ -271,6 +275,87 @@ Reviewer:    a, b, c"#,
                 (MessageSection::Reviewers, "a, b, c".to_string()),
             ]
             .into()
+        );
+    }
+
+    #[test]
+    fn test_parse_cherry_pick() {
+        let map = parse_message(
+            "My title\n\nPull Request: https://github.com/x/y/pull/1\nCherry Pick: true",
+            MessageSection::Title,
+        );
+        assert_eq!(
+            map.get(&MessageSection::Title).map(String::as_str),
+            Some("My title")
+        );
+        assert_eq!(
+            map.get(&MessageSection::PullRequest).map(String::as_str),
+            Some("https://github.com/x/y/pull/1")
+        );
+        assert_eq!(
+            map.get(&MessageSection::CherryPick).map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn test_build_commit_message_with_cherry_pick() {
+        let map: MessageSectionsMap = [
+            (MessageSection::Title, "My title".to_string()),
+            (
+                MessageSection::PullRequest,
+                "https://github.com/x/y/pull/1".to_string(),
+            ),
+            (MessageSection::CherryPick, "true".to_string()),
+        ]
+        .into();
+        let output = build_commit_message(&map);
+        // Cherry Pick must appear after Pull Request
+        let pr_pos = output.find("Pull Request:").unwrap();
+        let cp_pos = output.find("Cherry Pick:").unwrap();
+        assert!(
+            cp_pos > pr_pos,
+            "Cherry Pick should appear below Pull Request"
+        );
+        assert!(output.ends_with("Cherry Pick: true"));
+    }
+
+    #[test]
+    fn test_roundtrip_cherry_pick() {
+        let original = "My title\n\nPull Request: https://github.com/x/y/pull/1\nCherry Pick: true";
+        let map = parse_message(original, MessageSection::Title);
+        let rebuilt = build_commit_message(&map);
+        let reparsed = parse_message(&rebuilt, MessageSection::Title);
+        assert_eq!(
+            reparsed
+                .get(&MessageSection::CherryPick)
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            reparsed
+                .get(&MessageSection::PullRequest)
+                .map(String::as_str),
+            Some("https://github.com/x/y/pull/1")
+        );
+    }
+
+    #[test]
+    fn test_build_github_body_for_merging_omits_cherry_pick() {
+        let map: MessageSectionsMap = [
+            (MessageSection::Title, "My title".to_string()),
+            (MessageSection::Summary, "Some summary".to_string()),
+            (
+                MessageSection::PullRequest,
+                "https://github.com/x/y/pull/1".to_string(),
+            ),
+            (MessageSection::CherryPick, "true".to_string()),
+        ]
+        .into();
+        let body = build_github_body_for_merging(&map);
+        assert!(
+            !body.contains("Cherry Pick"),
+            "GitHub body should not contain Cherry Pick marker"
         );
     }
 

--- a/spr/tests/minimal_integration_test.rs
+++ b/spr/tests/minimal_integration_test.rs
@@ -323,6 +323,44 @@ fn test_list_command_behavior() {
 }
 
 // ============================================================================
+// CHERRY-PICK FLAG TESTS
+// ============================================================================
+
+#[test]
+fn test_diff_rejects_conflicting_cherry_pick_flags() {
+    let (_temp_dir, repo_path) = create_jj_repo();
+    let output = run_jj_spr(
+        &["diff", "--cherry-pick", "--no-cherry-pick"],
+        Some(&repo_path),
+    );
+    assert!(
+        !output.status.success(),
+        "Conflicting flags should cause a non-zero exit"
+    );
+    let all_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        all_output.contains("cannot be used with"),
+        "Error message should mention argument conflict, got: {}",
+        all_output
+    );
+}
+
+#[test]
+fn test_diff_help_mentions_no_cherry_pick() {
+    let output = run_jj_spr(&["diff", "--help"], None);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no-cherry-pick"),
+        "diff --help should document --no-cherry-pick"
+    );
+}
+
+// ============================================================================
 // INTEGRATION SUMMARY TEST
 // ============================================================================
 


### PR DESCRIPTION
When adding a PR with `jj spr diff --cherry-pick`, it's too easy to forget to add `--cherry-pick` when uploading a new version. Doing so retargets the pull request to a special base branch, which is undesirable.

Add a new description marker "Cherry Pick" that indicates a change was uploaded as a cherry pick. Doing so makes future invocations of `jj spr diff` automatically apply the `--cherry-pick` flag. To disable this, add `--no-cherry-pick`.