### PR TITLE
docs: update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,16 @@ git config spr.requireApproval true
 
 ## Documentation
 
-Full documentation is available at **[luciofranco.github.io/jj-spr](https://luciofranco.github.io/jj-spr/)**
+Full documentation is available at **[jennings.io/jj-spr](https://jennings.io/jj-spr/)**
 
 Quick links:
-- [Installation](https://luciofranco.github.io/jj-spr/user/installation.html) - Detailed installation instructions
-- [Setup](https://luciofranco.github.io/jj-spr/user/setup.html) - Initial configuration
-- [Simple PR Workflow](https://luciofranco.github.io/jj-spr/user/simple.html) - Single PR workflow guide
-- [Stacked PRs](https://luciofranco.github.io/jj-spr/user/stack.html) - Multi-PR workflows and stacking
-- [Commit Messages](https://luciofranco.github.io/jj-spr/user/commit-message.html) - Message format and sections
-- [Commands Reference](https://luciofranco.github.io/jj-spr/reference/commands.html) - Complete command reference
-- [Configuration](https://luciofranco.github.io/jj-spr/reference/configuration.html) - All configuration options
+- [Installation](https://jennings.io/jj-spr/user/installation.html) - Detailed installation instructions
+- [Setup](https://jennings.io/jj-spr/user/setup.html) - Initial configuration
+- [Simple PR Workflow](https://jennings.io/jj-spr/user/simple.html) - Single PR workflow guide
+- [Stacked PRs](https://jennings.io/jj-spr/user/stack.html) - Multi-PR workflows and stacking
+- [Commit Messages](https://jennings.io/jj-spr/user/commit-message.html) - Message format and sections
+- [Commands Reference](https://jennings.io/jj-spr/reference/commands.html) - Complete command reference
+- [Configuration](https://jennings.io/jj-spr/reference/configuration.html) - All configuration options
 
 ## Contributing
 


### PR DESCRIPTION
Summary
- Updates the README documentation links from the old luciofranco.github.io host to the current jennings.io/jj-spr site.
- Fixes the main documentation entry and all quick links in the Documentation section.
- Keeps the change scoped to README.md.

Validation
- `curl.exe -L -sS -o NUL -w "%{http_code} %{url_effective}"` for the documentation index and all seven quick links: all returned 200.
- `git diff --check -- README.md`: passed.
- `Select-String -Path README.md -Pattern 'luciofranco.github.io/jj-spr' -SimpleMatch`: no remaining matches.

Notes
- Fixes #137.
- README-only change; no runtime compatibility impact.
- I did not run `cargo test`, `cargo clippy`, `cargo fmt --check`, or `mdbook build` locally because `cargo` and `mdbook` are not installed in this environment, and the change only updates external documentation links.